### PR TITLE
fix: allow record types as params and return types

### DIFF
--- a/packages/fluorflow/example/lib/bottom_sheets/complex_return_type.dart
+++ b/packages/fluorflow/example/lib/bottom_sheets/complex_return_type.dart
@@ -1,0 +1,12 @@
+import 'package:fluorflow/fluorflow.dart';
+import 'package:flutter/material.dart';
+
+class Foobar {}
+
+final class ComplexReturnTypeSheet
+    extends FluorFlowSimpleBottomSheet<(int, {Foobar f})> {
+  const ComplexReturnTypeSheet({super.key, required super.completer});
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/fluorflow_generator/lib/src/builder/bottom_sheet_builder.dart
+++ b/packages/fluorflow_generator/lib/src/builder/bottom_sheet_builder.dart
@@ -63,7 +63,7 @@ class BottomSheetBuilder implements Builder {
           ..positionalFieldTypes.add(refer('bool?'))
           ..positionalFieldTypes.add(recursiveTypeReference(
               lib, sheetReturnType,
-              typeRefUpdates: (b) => b.isNullable = true)));
+              forceNullable: true)));
         final params = sheetClass.constructors.first.parameters
             .where(
                 (p) => p.displayName != 'key' && p.displayName != 'completer')

--- a/packages/fluorflow_generator/lib/src/builder/dialog_builder.dart
+++ b/packages/fluorflow_generator/lib/src/builder/dialog_builder.dart
@@ -64,7 +64,7 @@ class DialogBuilder implements Builder {
           ..positionalFieldTypes.add(refer('bool?'))
           ..positionalFieldTypes.add(recursiveTypeReference(
               lib, dialogReturnType,
-              typeRefUpdates: (b) => b.isNullable = true)));
+              forceNullable: true)));
         final params = dialogClass.constructors.first.parameters
             .where(
                 (p) => p.displayName != 'key' && p.displayName != 'completer')

--- a/packages/fluorflow_generator/lib/src/builder/router_builder.dart
+++ b/packages/fluorflow_generator/lib/src/builder/router_builder.dart
@@ -83,8 +83,7 @@ class RouterBuilder implements Builder {
             ..fields.addAll(params.map((p) => Field((b) => b
               ..name = p.displayName
               ..modifier = FieldModifier.final$
-              ..type = refer(p.type.getDisplayString(withNullability: true),
-                  lib.pathToElement(p.type.element!).toString()))))
+              ..type = recursiveTypeReference(lib, p.type))))
             ..constructors.add(Constructor((b) => b
               ..constant = true
               ..optionalParameters.addAll(params.map((p) => Parameter((b) => b
@@ -229,8 +228,7 @@ class RouterBuilder implements Builder {
           ])
           ..optionalParameters.addAll(params.map((p) => Parameter((b) => b
             ..name = p.name
-            ..type = refer(p.type.getDisplayString(withNullability: true),
-                lib.pathToElement(p.type.element!).toString())
+            ..type = recursiveTypeReference(lib, p.type)
             ..required = p.isRequired
             ..defaultTo = p.hasDefaultValue ? Code(p.defaultValueCode!) : null
             ..named = true)))

--- a/packages/fluorflow_generator/lib/src/utils.dart
+++ b/packages/fluorflow_generator/lib/src/utils.dart
@@ -27,28 +27,40 @@ cb.Reference recursiveTypeReference(
       cb.refer(t.getDisplayString(withNullability: false)),
     DartType(alias: InstantiatedTypeAliasElement(:final element)) =>
       cb.refer(element.name, lib.pathToElement(element).toString()),
-    final FunctionType f => cb.FunctionType((b) => b
-      ..returnType = mapRef(f.returnType)
-      ..requiredParameters.addAll(f.parameters
-          .where((p) => p.isRequiredPositional)
-          .map((p) => p.type)
-          .map(mapRef))
-      ..optionalParameters.addAll(f.parameters
-          .where((p) => p.isOptionalPositional)
-          .map((p) => p.type)
-          .map(mapRef))
-      ..namedRequiredParameters.addAll({
-        for (final p in f.parameters.where((p) => p.isRequiredNamed))
-          p.name: mapRef(p.type)
-      })
-      ..namedParameters.addAll({
-        for (final p in f.parameters.where((p) => p.isOptionalNamed))
-          p.name: mapRef(p.type)
-      })
-      ..types.addAll(f.typeFormals
-          .where((tf) => tf.bound != null)
-          .map((tf) => tf.bound!)
-          .map(mapRef))),
+    FunctionType(:final returnType, :final parameters, :final typeFormals) =>
+      cb.FunctionType((b) => b
+        ..returnType = mapRef(returnType)
+        ..requiredParameters.addAll(parameters
+            .where((p) => p.isRequiredPositional)
+            .map((p) => p.type)
+            .map(mapRef))
+        ..optionalParameters.addAll(parameters
+            .where((p) => p.isOptionalPositional)
+            .map((p) => p.type)
+            .map(mapRef))
+        ..namedRequiredParameters.addAll({
+          for (final p in parameters.where((p) => p.isRequiredNamed))
+            p.name: mapRef(p.type)
+        })
+        ..namedParameters.addAll({
+          for (final p in parameters.where((p) => p.isOptionalNamed))
+            p.name: mapRef(p.type)
+        })
+        ..types.addAll(typeFormals
+            .where((tf) => tf.bound != null)
+            .map((tf) => tf.bound!)
+            .map(mapRef))),
+    RecordType(
+      :final positionalFields,
+      :final namedFields,
+      :final nullabilitySuffix
+    ) =>
+      cb.RecordType((b) => b
+        ..isNullable = nullabilitySuffix == NullabilitySuffix.question
+        ..positionalFieldTypes
+            .addAll(positionalFields.map((f) => mapRef(f.type)))
+        ..namedFieldTypes.addIterable(namedFields,
+            key: (f) => f.name, value: (f) => mapRef(f.type))),
     _ => cb.TypeReference((b) => b
           ..isNullable = t.nullabilitySuffix == NullabilitySuffix.question
           ..symbol =

--- a/packages/fluorflow_generator/test/builder/bottom_sheet_builder_test.dart
+++ b/packages/fluorflow_generator/test/builder/bottom_sheet_builder_test.dart
@@ -1143,6 +1143,134 @@ extension BottomSheets on _i1.BottomSheetService {
               reader: await PackageAssetReader.currentIsolate()));
     });
 
+    group('for Bottom Sheet with special return types', () {
+      test(
+          'should generate sheet method that returns record type.',
+          () async => await testBuilder(
+              BottomSheetBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MySheet extends FluorFlowSimpleBottomSheet<(int, int)> {
+                  const MySheet({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.bottom_sheets.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension BottomSheets on _i1.BottomSheetService {
+  Future<(bool?, (int, int)?)> showMySheet({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool fullscreen = false,
+    bool ignoreSafeArea = true,
+    bool draggable = true,
+  }) =>
+      showBottomSheet<(bool?, (int, int)?), _i3.MySheet>(
+        _i3.MySheet(completer: closeSheet),
+        barrierColor: barrierColor,
+        fullscreen: fullscreen,
+        draggable: draggable,
+        ignoreSafeArea: ignoreSafeArea,
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate sheet method that returns named record type.',
+          () async => await testBuilder(
+              BottomSheetBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MySheet extends FluorFlowSimpleBottomSheet<({int a})> {
+                  const MySheet({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.bottom_sheets.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension BottomSheets on _i1.BottomSheetService {
+  Future<(bool?, ({int a})?)> showMySheet({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool fullscreen = false,
+    bool ignoreSafeArea = true,
+    bool draggable = true,
+  }) =>
+      showBottomSheet<(bool?, ({int a})?), _i3.MySheet>(
+        _i3.MySheet(completer: closeSheet),
+        barrierColor: barrierColor,
+        fullscreen: fullscreen,
+        draggable: draggable,
+        ignoreSafeArea: ignoreSafeArea,
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate sheet method that returns function type.',
+          () async => await testBuilder(
+              BottomSheetBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MySheet extends FluorFlowSimpleBottomSheet<void Function()> {
+                  const MySheet({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.bottom_sheets.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension BottomSheets on _i1.BottomSheetService {
+  Future<(bool?, void Function()?)> showMySheet({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool fullscreen = false,
+    bool ignoreSafeArea = true,
+    bool draggable = true,
+  }) =>
+      showBottomSheet<(bool?, void Function()?), _i3.MySheet>(
+        _i3.MySheet(completer: closeSheet),
+        barrierColor: barrierColor,
+        fullscreen: fullscreen,
+        draggable: draggable,
+        ignoreSafeArea: ignoreSafeArea,
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+    });
+
     group('with @BottomSheetConfig()', () {
       test(
           'should generate sheet method with custom default options.',

--- a/packages/fluorflow_generator/test/builder/dialog_builder_test.dart
+++ b/packages/fluorflow_generator/test/builder/dialog_builder_test.dart
@@ -1192,6 +1192,140 @@ extension Dialogs on _i1.DialogService {
               reader: await PackageAssetReader.currentIsolate()));
     });
 
+    group('for Dialog with special return types', () {
+      test(
+          'should generate dialog method that returns record type.',
+          () async => await testBuilder(
+              DialogBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MyDialog extends FluorFlowSimpleDialog<(int, int)> {
+                  const MyDialog({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.dialogs.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension Dialogs on _i1.DialogService {
+  Future<(bool?, (int, int)?)> showMyDialog({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool barrierDismissible = false,
+  }) =>
+      showDialog<(bool?, (int, int)?)>(
+        barrierColor: barrierColor,
+        barrierDismissible: barrierDismissible,
+        dialogBuilder: _i1.NoTransitionPageRouteBuilder(
+            pageBuilder: (
+          _,
+          __,
+          ___,
+        ) =>
+                _i3.MyDialog(completer: closeDialog)),
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate dialog method that returns named record type.',
+          () async => await testBuilder(
+              DialogBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MyDialog extends FluorFlowSimpleDialog<({int a})> {
+                  const MyDialog({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.dialogs.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension Dialogs on _i1.DialogService {
+  Future<(bool?, ({int a})?)> showMyDialog({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool barrierDismissible = false,
+  }) =>
+      showDialog<(bool?, ({int a})?)>(
+        barrierColor: barrierColor,
+        barrierDismissible: barrierDismissible,
+        dialogBuilder: _i1.NoTransitionPageRouteBuilder(
+            pageBuilder: (
+          _,
+          __,
+          ___,
+        ) =>
+                _i3.MyDialog(completer: closeDialog)),
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate dialog method that returns function type.',
+          () async => await testBuilder(
+              DialogBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                import 'package:fluorflow/fluorflow.dart';
+
+                class MyDialog extends FluorFlowSimpleDialog<void Function()> {
+                  const MyDialog({super.key, required this.completer});
+                }
+              '''
+              },
+              outputs: {
+                'a|lib/app.dialogs.dart': r'''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:ui' as _i2;
+
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i1;
+
+extension Dialogs on _i1.DialogService {
+  Future<(bool?, void Function()?)> showMyDialog({
+    _i2.Color barrierColor = const _i2.Color(0x80000000),
+    bool barrierDismissible = false,
+  }) =>
+      showDialog<(bool?, void Function()?)>(
+        barrierColor: barrierColor,
+        barrierDismissible: barrierDismissible,
+        dialogBuilder: _i1.NoTransitionPageRouteBuilder(
+            pageBuilder: (
+          _,
+          __,
+          ___,
+        ) =>
+                _i3.MyDialog(completer: closeDialog)),
+      ).then((r) => (r?.$1, r?.$2));
+}
+'''
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+    });
+
     group('with @DialogConfig()', () {
       test(
           'should generate dialog method with custom default barrier color.',

--- a/packages/fluorflow_generator/test/builder/router_builder_test.dart
+++ b/packages/fluorflow_generator/test/builder/router_builder_test.dart
@@ -1228,5 +1228,1203 @@ extension RouteNavigation on _i2.NavigationService {
               },
               reader: await PackageAssetReader.currentIsolate()));
     });
+
+    group('with special view argument types', () {
+      test(
+          'should generate arguments for generic list with primitive type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final List<int> arg;
+                    const View(this.arg, {super.key});
+                  }
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final List<int> arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required List<int> arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required List<int> arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required List<int> arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for generic list with complex type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  class Foobar {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final List<Foobar> arg;
+                    const View(this.arg, {super.key});
+                  }
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final List<_i3.Foobar> arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required List<_i3.Foobar> arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required List<_i3.Foobar> arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required List<_i3.Foobar> arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for record type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  class Foobar {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final (Foobar, int, {String name, Foobar f}) arg;
+                    const View(this.arg, {super.key});
+                  }
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final (_i3.Foobar, int, {_i3.Foobar f, String name}) arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required (_i3.Foobar, int, {_i3.Foobar f, String name}) arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required (_i3.Foobar, int, {_i3.Foobar f, String name}) arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView(
+          {required (_i3.Foobar, int, {_i3.Foobar f, String name}) arg}) =>
+      rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for nullable record type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  class Foobar {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final (Foobar, int)? arg;
+                    const View({super.key, this.arg});
+                  }
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(arg: args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({this.arg});
+
+  final (_i3.Foobar, int)? arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    (_i3.Foobar, int)? arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    (_i3.Foobar, int)? arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({(_i3.Foobar, int)? arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for recursive generic type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  class Foo<T> {}
+                  class Bar<T, T2> {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final Foo<Bar<Baz, int>> arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Baz {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i3.Foo<_i3.Bar<_i4.Baz, int>> arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i3.Foo<_i3.Bar<_i4.Baz, int>> arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i3.Foo<_i3.Bar<_i4.Baz, int>> arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i3.Foo<_i3.Bar<_i4.Baz, int>> arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for aliased import type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart' as b;
+
+                  class Foo<T> {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final Foo<b.Baz> arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Baz {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i3.Foo<_i4.Baz> arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i3.Foo<_i4.Baz> arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i3.Foo<_i4.Baz> arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i3.Foo<_i4.Baz> arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for function type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final void Function() arg;
+                    const View(this.arg, {super.key});
+                  }
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final void Function() arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required void Function() arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required void Function() arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required void Function() arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for complex function type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  class Foo {}
+                  
+                  class Bar<T> {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final Foo Function(Bar<Baz> i) arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Baz {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i3.Foo Function(_i3.Bar<_i4.Baz>) arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i3.Foo Function(_i3.Bar<_i4.Baz>) arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i3.Foo Function(_i3.Bar<_i4.Baz>) arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i3.Foo Function(_i3.Bar<_i4.Baz>) arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for complex function with named parameters type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  class Foo {}
+                  
+                  class Bar<T> {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final Foo Function(Bar<Baz> i, { required Foo f, Baz? b }) arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Baz {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i3.Foo Function(
+    _i3.Bar<_i4.Baz>, {
+    required _i3.Foo f,
+    _i4.Baz? b,
+  }) arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i3.Foo Function(
+      _i3.Bar<_i4.Baz>, {
+      required _i3.Foo f,
+      _i4.Baz? b,
+    }) arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i3.Foo Function(
+      _i3.Bar<_i4.Baz>, {
+      required _i3.Foo f,
+      _i4.Baz? b,
+    }) arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView(
+          {required _i3.Foo Function(
+            _i3.Bar<_i4.Baz>, {
+            required _i3.Foo f,
+            _i4.Baz? b,
+          }) arg}) =>
+      rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for complex function with optional parameters type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  class Foo {}
+                  
+                  class Bar<T> {}
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final Foo Function(Bar<Baz> i, [Foo? f]) arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Baz {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i3.Foo Function(
+    _i3.Bar<_i4.Baz>, [
+    _i3.Foo?,
+  ]) arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i3.Foo Function(
+      _i3.Bar<_i4.Baz>, [
+      _i3.Foo?,
+    ]) arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i3.Foo Function(
+      _i3.Bar<_i4.Baz>, [
+      _i3.Foo?,
+    ]) arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView(
+          {required _i3.Foo Function(
+            _i3.Bar<_i4.Baz>, [
+            _i3.Foo?,
+          ]) arg}) =>
+      rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for aliased type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final MyCallback arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                class Foobar {}
+
+                typedef MyCallback = void Function(Foobar);
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i4.MyCallback arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i4.MyCallback arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i4.MyCallback arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i4.MyCallback arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for aliased tuple type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final MyTuple arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                import 'c.dart';
+
+                typedef MyTuple = (int, Foobar);
+              ''',
+                'a|lib/c.dart': '''
+                class Foobar {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i4.MyTuple arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i4.MyTuple arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i4.MyTuple arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i4.MyTuple arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+
+      test(
+          'should generate arguments for aliased record type.',
+          () async => await testBuilder(
+              RouterBuilder(BuilderOptions.empty),
+              {
+                'a|lib/a.dart': '''
+                  import 'package:fluorflow/annotations.dart';
+                  import 'package:flutter/material.dart';
+
+                  import 'b.dart';
+
+                  @Routable()
+                  class View extends StatelessWidget {
+                    final MyRecord arg;
+                    const View(this.arg, {super.key});
+                  }
+              ''',
+                'a|lib/b.dart': '''
+                import 'c.dart';
+
+                typedef MyRecord = ({int age, Foobar foo});
+              ''',
+                'a|lib/c.dart': '''
+                class Foobar {}
+              '''
+              },
+              outputs: {
+                'a|lib/app.router.dart': '''
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:a/a.dart' as _i3;
+import 'package:a/b.dart' as _i4;
+import 'package:fluorflow/fluorflow.dart' as _i2;
+import 'package:flutter/widgets.dart' as _i1;
+
+enum AppRoute {
+  view('/view');
+
+  const AppRoute(this.path);
+
+  final String path;
+}
+
+final _pages = <String, _i1.RouteFactory>{
+  AppRoute.view.path: (data) => _i2.NoTransitionPageRouteBuilder(
+        settings: data,
+        pageBuilder: (
+          _,
+          __,
+          ___,
+        ) {
+          final args = (data.arguments as ViewArguments);
+          return _i3.View(args.arg);
+        },
+      )
+};
+
+class ViewArguments {
+  const ViewArguments({required this.arg});
+
+  final _i4.MyRecord arg;
+}
+
+final onGenerateRoute = _i2.generateRouteFactory(_pages);
+
+extension RouteNavigation on _i2.NavigationService {
+  Future<T?>? navigateToView<T>({
+    required _i4.MyRecord arg,
+    bool preventDuplicates = true,
+  }) =>
+      navigateTo(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void replaceWithView({
+    required _i4.MyRecord arg,
+    bool preventDuplicates = true,
+  }) =>
+      replaceWith(
+        AppRoute.view.path,
+        preventDuplicates: preventDuplicates,
+        arguments: ViewArguments(arg: arg),
+      );
+  void rootToView({required _i4.MyRecord arg}) => rootTo(
+        AppRoute.view.path,
+        arguments: ViewArguments(arg: arg),
+      );
+}
+''',
+              },
+              reader: await PackageAssetReader.currentIsolate()));
+    });
   });
 }


### PR DESCRIPTION
This allows more complex types to be used in
return types and parameter types for bottom
sheets, dialogs, and routes.
Types like `(int, int, {String foobar})` or
referenced types (imports from other files) are
supported.