### PR TITLE
feat(navigation): add platform specific page builder

### DIFF
--- a/packages/fluorflow/example/lib/views/detail/detail_view.dart
+++ b/packages/fluorflow/example/lib/views/detail/detail_view.dart
@@ -7,7 +7,7 @@ import 'detail_viewmodel.dart';
 @Routable(
     replaceWithExtension: false,
     rootToExtension: false,
-    routeBuilder: RouteBuilder.leftToRight)
+    routeBuilder: RouteBuilder.platform)
 final class DetailView extends FluorFlowView<DetailViewModel> {
   const DetailView({super.key});
 

--- a/packages/fluorflow/example/lib/views/home/home_view.dart
+++ b/packages/fluorflow/example/lib/views/home/home_view.dart
@@ -4,7 +4,10 @@ import 'package:flutter/material.dart';
 
 import 'home_viewmodel.dart';
 
-@Routable(navigateToExtension: false, replaceWithExtension: false)
+@Routable(
+    navigateToExtension: false,
+    replaceWithExtension: false,
+    routeBuilder: RouteBuilder.fadeIn)
 final class HomeView extends FluorFlowView<HomeViewModel> {
   const HomeView({super.key});
 

--- a/packages/fluorflow/lib/src/navigation/page_route_builder.dart
+++ b/packages/fluorflow/lib/src/navigation/page_route_builder.dart
@@ -1,8 +1,29 @@
-import 'package:flutter/widgets.dart';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
 
 /// A custom page route builder that provides a page transition without any animation.
 class NoTransitionPageRouteBuilder extends PageRouteBuilder {
   NoTransitionPageRouteBuilder({super.settings, required super.pageBuilder});
+}
+
+/// A custom page route builder that provides transitions
+/// that should match the defaults of the underlying platform.
+class PlatformPageRouteBuilder extends PageRouteBuilder {
+  static const _ios = CupertinoPageTransitionsBuilder();
+  static const _other = FadeUpwardsPageTransitionsBuilder();
+
+  PlatformPageRouteBuilder({super.settings, required super.pageBuilder});
+
+  @override
+  Widget buildTransitions(BuildContext context, Animation<double> animation,
+          Animation<double> secondaryAnimation, Widget child) =>
+      switch (Platform.operatingSystem) {
+        'ios' || 'macos' => _ios.buildTransitions(
+            this, context, animation, secondaryAnimation, child),
+        _ => _other.buildTransitions(
+            this, context, animation, secondaryAnimation, child),
+      };
 }
 
 /// A custom page route builder that provides a fade-in transition effect.

--- a/packages/fluorflow/lib/src/navigation/route_builder.dart
+++ b/packages/fluorflow/lib/src/navigation/route_builder.dart
@@ -3,6 +3,11 @@ enum RouteBuilder {
   /// No transition.
   noTransition,
 
+  /// Platform default transition.
+  /// For iOS / macOS devices, this uses the cuperino transition which supports
+  /// the swipe back gesture. All other devices use the fade upwards transition.
+  platform,
+
   /// Fade in transition.
   fadeIn,
 


### PR DESCRIPTION
This adds the `PlatformPageRouteBuilder`
which uses native animations to route
between pages. Cupertino is used for
ios and macos with the swipe back gesture
and fade upwards for all other devices.
